### PR TITLE
use example.yml in repo, store s3 keys in secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+config/secrets.yml

--- a/app/models/photo_image.rb
+++ b/app/models/photo_image.rb
@@ -5,6 +5,10 @@ class PhotoImage < ApplicationRecord
   validates_attachment_content_type :main, content_type: /\Aimage\/.*\Z/
 
   def s3_credentials
-    { bucket: "photo-image-collection", access_key_id: 'AKIAJAUQ5GCWDILB754Q', secret_access_key: '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' }
+    {
+      bucket: "photo-image-collection",
+      access_key_id: Rails.application.secrets.s3_access_key,
+      secret_access_key: Rails.application.secrets.s3_secret_key
+    }
   end
 end

--- a/config/secrets.example.yml
+++ b/config/secrets.example.yml
@@ -12,6 +12,8 @@
 
 development:
   secret_key_base: cec7269b7d9a6e16553f2502c3afcd7636bbcc2a3a3f5b7c895f7900a87b888b615048781daee0bdd446524e2824fb7260c2ac8592266a8d50a644060b48ecd9
+  s3_access_key: 4cc3ssk3yh3re
+  s3_secret_key: s3k3yh3r3
 
 test:
   secret_key_base: 4e0ca5b9069cbd0c20a1cf64ccc6d088d1ef0ecfbec74f9570b73cf686aafc6266c5503b70b7aef697d769842095af6f34fb93743f6aed8cf45660ff4f575b1b


### PR DESCRIPTION
fixes s3 key leakage. Remember to copy secrets.example.yml -> secrets.yml and set the real values. .gitignore entry will prevent future leakage.